### PR TITLE
Delete CreatePrimaryRequest and DeletePrimaryRequest

### DIFF
--- a/core/src/edu/rice/rbox/Protos/rbox.proto
+++ b/core/src/edu/rice/rbox/Protos/rbox.proto
@@ -23,23 +23,10 @@ message UpdateMessage {
 	bytes remoteChange = 2;
 }
 
-message CreatePrimaryRequest {
-	ReplicationMessage msg = 1;
-	map<string, bytes> interestingFields = 2;
-}
-
-message DeletePrimaryRequest {
-	ReplicationMessage msg = 1;
-}
 
 // this is the ONLY service defined (all RPCs go here)
 service RBoxService {
-    // Replication <=> Replication
     rpc handleSubscribe(SubscribeRequest) returns (UpdateMessage);
   	rpc handleUpdate(UpdateMessage) returns (google.protobuf.Empty);
     rpc handleUnsubscribe(UnsubscribeRequest) returns (google.protobuf.Empty);
-
-    // Replication => Registrar
-    rpc handleCreatePrimary(CreatePrimaryRequest) returns (google.protobuf.Empty);
-    rpc handleDeletePrimary(DeletePrimaryRequest) returns (google.protobuf.Empty);
 }


### PR DESCRIPTION
As ObjectLocation is no longer on the registrar, replication no longer need these two messages to communicate with Location.

## Change ##
Delete two rpc and messages from `rbox.proto`
- CreatePrimaryRequest
- DeletePrimaryRequest

## TODO ##
- [x] Generate new grpc files